### PR TITLE
Origin Access Identity Support

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -64,6 +64,11 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:provider.stage}-${self:service}-static-assets
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
 
     StaticAssetsS3BucketPolicy:
       Type: AWS::S3::BucketPolicy

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,9 +1,9 @@
-service: 'sveltekit-app'
+service: "sveltekit-app"
 
 frameworkVersion: "3"
 
 plugins:
-  - '@silvermine/serverless-plugin-cloudfront-lambda-edge'
+  - "@silvermine/serverless-plugin-cloudfront-lambda-edge"
   - serverless-s3-deploy
 
 provider:
@@ -25,22 +25,21 @@ custom:
   assets:
     auto: true
     targets:
-      - bucket: 
+      - bucket:
           Ref: StaticAssets
         files:
           - source: ./build/assets/
-            globs: 
-              - '**'
+            globs:
+              - "**"
             empty: true
             headers:
               CacheControl: max-age=31104000
           - source: ./build/prerendered/
-            globs: 
-              - '**'
+            globs:
+              - "**"
             empty: true
             headers:
               CacheControl: max-age=60
-
 
 functions:
   #SSR Function
@@ -56,7 +55,7 @@ functions:
     memorySize: 128
     timeout: 1
     lambdaAtEdge:
-      distribution: 'WebsiteDistribution'
+      distribution: "WebsiteDistribution"
       eventType: origin-request
 
 resources:
@@ -64,7 +63,6 @@ resources:
     StaticAssets:
       Type: AWS::S3::Bucket
       Properties:
-        AccessControl: PublicRead
         BucketName: ${self:provider.stage}-${self:service}-static-assets
 
     StaticAssetsS3BucketPolicy:
@@ -74,35 +72,54 @@ resources:
           Ref: StaticAssets
         PolicyDocument:
           Statement:
-            - Sid: PublicReadGetObject
+            - Sid: PolicyForCloudFrontPrivateContent
               Effect: Allow
-              Principal: "*"
+              Principal:
+                AWS:
+                  Fn::Join:
+                    [
+                      "",
+                      ["arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ", { "Ref": "StaticAssetsOAI" }],
+                    ]
               Action:
                 - s3:GetObject
               Resource:
                 Fn::Join: ["", ["arn:aws:s3:::", { "Ref": "StaticAssets" }, "/*"]]
 
+    StaticAssetsOAI:
+      Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+      Properties:
+        CloudFrontOriginAccessIdentityConfig:
+          Comment: "Access Identity for ${self:service} (${self:provider.stage})"
+
     WebsiteDistribution:
-      Type: 'AWS::CloudFront::Distribution'
+      Type: "AWS::CloudFront::Distribution"
       Properties:
         DistributionConfig:
           Origins:
-            -
-              DomainName: !Select [2, !Split ["/", !GetAtt ["SvelteLambdaFunctionUrl", "FunctionUrl"]]]
-              Id: default
-              OriginCustomHeaders: 
+            - DomainName: !Select [2, !Split ["/", !GetAtt ["SvelteLambdaFunctionUrl", "FunctionUrl"]]]
+              Id: svelte-server
+              OriginCustomHeaders:
                 #Lambda@edge does not support ENV vars, so instead we have to pass in a customHeaders.
-                -
-                  HeaderName: 's3-host'
-                  HeaderValue: '${self:provider.stage}-${self:service}-static-assets.s3.amazonaws.com'
+                - HeaderName: "s3-host"
+                  HeaderValue: "${self:provider.stage}-${self:service}-static-assets.s3.amazonaws.com"
               CustomOriginConfig:
                 HTTPPort: 80
                 HTTPSPort: 443
-                OriginProtocolPolicy: 'https-only'
+                OriginProtocolPolicy: "https-only"
+            - DomainName: !GetAtt ["StaticAssets", "DomainName"]
+              Id: static-assets
+              OriginCustomHeaders:
+                #Lambda@edge does not support ENV vars, so instead we have to pass in a customHeaders.
+                - HeaderName: "lambda-domain"
+                  HeaderValue: !Select [2, !Split ["/", !GetAtt ["SvelteLambdaFunctionUrl", "FunctionUrl"]]]
+              S3OriginConfig:
+                OriginAccessIdentity:
+                  Fn::Join: ["", ["origin-access-identity/cloudfront/", { "Ref": "StaticAssetsOAI" }]]
           Enabled: true
-          Comment: '${self:service}_${self:provider.stage}'
+          Comment: "${self:service}_${self:provider.stage}"
           DefaultCacheBehavior:
-            TargetOriginId: default
+            TargetOriginId: static-assets
             Compress: true
             AllowedMethods:
               - DELETE
@@ -120,4 +137,4 @@ resources:
               Cookies:
                 Forward: all
               QueryString: True
-            ViewerProtocolPolicy: 'redirect-to-https'
+            ViewerProtocolPolicy: "redirect-to-https"

--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,7 @@ exports.handler = (event, context, callback) => {
   if (uri.slice(-1) === "/") {
     uri += "index.html";
   }
-  if (static_default.includes(uri)) {
+  if (staticFiles.includes(uri)) {
     request.uri = uri;
   } else {
     const domainName = request.origin.s3.customHeaders["lambda-domain"][0].value;


### PR DESCRIPTION
This PR is not necessarily intended to be merged in but I wanted to highlight a use case that this fork addresses and see if it's worth discussing further.

In it's current state, the S3 static asset bucket is created with public read permissions, making it possible for anybody to fetch the content directly from S3, bypassing the CloudFront distribution. This is fine for most uses cases but sometimes we might want to lock a bucket down so that it is not public and the content can only be accessed via CloudFront, either with Origin Access Control (OAC), or the now legacy Origin Access Identity (OAI).

According to the [AWS Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html) for the `authMethod` property of the Lambda@Edge event structure, OAC is not supported, so we are forced to use OAI by setting the `origin.authMethod` of the request object to "origin-access-identity". Unfortunately, one of the caveats of this means that we cannot switch from a lambda origin to an S3 origin and maintain OAI authentication.

As it currently works, the default origin behavior of the CF distribution is to default the origin to be the Svelte app server lambda and switch to the static asset S3 origin when necessary, so switching to the S3 origin with OAI access permissions will result in every static asset returning a 403. However, I have found that inverting this logic, and making the S3 bucket the default origin will work with OAI.

In order to get my use case working, I had to do the following:
- Manually create the S3 bucket as an origin for the CF distribution with OAI enabled. (Setting the svelte app server lambda as an origin in the serverless config is optional but I chose to do it to be explicit).
- Set the default distribution behavior to default the origin to the static S3 bucket. This forces every origin request to invoke the lambda in an S3 origin context.
- Invert the logic in the origin request lambda handler to route requests to the svelte app lambda origin when the request URI doesn't match any static assets, otherwise don't modify the request at all and let it hit the S3 origin as is, maintaining OAI authentication.

This method allows OAI authentication to work at the expense of making the logic in the origin request lambda handler a little bit less intuitive.

With all that being said, the app that I am using this for is a prototype so I am more than happy to continue to use this forked version that serves my use case but I wanted to bring it to your attention in case you felt like this was valuable to know.