### PR TITLE
[Fix] - Adding S3 Bucket Public ACL Controls

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -64,8 +64,15 @@ resources:
     StaticAssets:
       Type: AWS::S3::Bucket
       Properties:
-        AccessControl: PublicRead
         BucketName: ${self:provider.stage}-${self:service}-static-assets
+        OwnershipControls:
+          Rules:
+            - ObjectOwnership: BucketOwnerPreferred
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: false
+          BlockPublicPolicy: false
+          IgnorePublicAcls: false
+          RestrictPublicBuckets: false
 
     StaticAssetsS3BucketPolicy:
       Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
Due to an update AWS pushed on S3 this year in April the current serverless.yml no longer allows deployment. The changes are specific to the new ways AWS wants users to handle Access Control - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/.

I've added a tweak to the serverless.yml to hopefully avoid the issue if anyone else tries to use the package + deployment package.