### PR TITLE
AWS is deprecating lambda runtime node16 in a few months

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   lambdaHashingVersion: 20201221
   region: us-east-1 #Lambda@Edge must be deployed in us-east-1
   stage: ${opt:stage, 'dev'}


### PR DESCRIPTION
SvelteKit 1 is compatible with Node18 and Node16 will be deprecated as a lambda runtime in a few months. I think it is time to update the runtime.

[Here is additional information from the lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#:~:text=Node.js%2016,Aug%2015%2C%202024)
